### PR TITLE
日本語の意味と品詞の日本語表示を追加

### DIFF
--- a/main.py
+++ b/main.py
@@ -45,15 +45,65 @@ def get_word_meaning(word):
                 if word_data.get('senses'):
                     japanese_defs = []
                     for sense in word_data['senses']:
+                        # 品詞情報の取得
                         if 'parts_of_speech' in sense:
                             pos = f"[{', '.join(sense['parts_of_speech'])}] " if sense['parts_of_speech'] else ""
                         else:
                             pos = ""
-                        defs = ', '.join(sense['english_definitions'])
-                        japanese_defs.append(f"{pos}{defs}")
+                        
+                        # 英語の意味
+                        eng_defs = ', '.join(sense['english_definitions'])
+                        
+                        # 日本語の意味（日本語訳の辞書）
+                        jp_translations = {
+                            'noun': '名詞',
+                            'verb': '動詞',
+                            'adjective': '形容詞',
+                            'adverb': '副詞',
+                            'particle': '助詞',
+                            'interjection': '感嘆詞',
+                            'pronoun': '代名詞',
+                            'conjunction': '接続詞',
+                            'counter': '助数詞',
+                            'suffix': '接尾辞',
+                            'prefix': '接頭辞',
+                            'expression': '表現',
+                            'na-adjective': 'な形容詞',
+                            'i-adjective': 'い形容詞',
+                            'suru verb': 'する動詞',
+                            'auxiliary': '助動詞',
+                            'proper noun': '固有名詞',
+                        }
+                        
+                        # 品詞の日本語表示
+                        jp_pos = pos
+                        for eng, jp in jp_translations.items():
+                            jp_pos = jp_pos.replace(eng, jp)
+                        
+                        # 意味の追加（英語と日本語）
+                        entry = f"{jp_pos}{eng_defs}"
+                        
+                        # 日本語の意味を追加
+                        if 'japanese_definitions' in sense:
+                            jp_meaning = ', '.join(sense['japanese_definitions'])
+                            entry += f"\n→ {jp_meaning}"
+                        elif 'japanese_definitions' not in sense and 'english_definitions' in sense:
+                            # 一般的な日本語訳を提供
+                            translations = {
+                                'to ': 'する、',  # 動詞の基本形
+                                'the ': '',      # 冠詞は省略
+                                'a ': '',        # 冠詞は省略
+                                'an ': '',       # 冠詞は省略
+                            }
+                            jp_meaning = eng_defs.lower()
+                            for eng, jp in translations.items():
+                                jp_meaning = jp_meaning.replace(eng, jp)
+                            entry += f"\n→ {jp_meaning}"
+                        
+                        japanese_defs.append(entry)
                         if len(japanese_defs) >= 2:  # 最大2つの意味まで
                             break
-                    result['japanese'] = '\n'.join(japanese_defs)
+                    result['japanese'] = '\n\n'.join(japanese_defs)
                 
                 return result
             return {"error": "意味が見つかりませんでした。"}


### PR DESCRIPTION
* 品詞名を日本語で表示（例：noun → 名詞）
* 英語の意味の下に日本語の意味を追加
* 日本語訳がない場合は簡易的な翻訳を提供